### PR TITLE
Fix playground url in codegen.yml sample

### DIFF
--- a/setup/graphql-code-generator.md
+++ b/setup/graphql-code-generator.md
@@ -40,7 +40,7 @@ Finally, we need to configure the generator using the `codegen.yml` configuratio
 
 ```yaml
 overwrite: true
-schema: "https://tutorial.saleor.cloud/graphql/"
+schema: "https://vercel.saleor.cloud/graphql/"
 documents: "graphql/**/*.{ts,graphql}"
 generates:
   saleor/api.tsx:


### PR DESCRIPTION
`npx graphql-codegen --config codegen.yml` generates:
```
Failed to load schema from https://tutorial.saleor.cloud/graphql/:

        invalid json response body at https://tutorial.saleor.cloud/graphql/ reason: Unexpected token < in JSON at position 0
```

It seems to fix #21 