### PR TITLE
Fix broken links in ToC

### DIFF
--- a/cli/getting-started.md
+++ b/cli/getting-started.md
@@ -41,11 +41,11 @@ To download and install Saleor CLI, run the following command:
 
 `npm i -g saleor-cli@latest`
 
-## Getting -help
+## Getting Help
 
 Typing `saleor` in the terminal will display a list of possible commands and their descriptions. Typing `saleor <command>` will display additional comands list for this particular command. This way, you can navigate over the interface to trigger specific actions.
 
-## Logging in / Registering
+## Logging in or Registering
 
 Firstly, you need to login into an existing Saleor Cloud account or create a new one. In order to log in let's type:
 


### PR DESCRIPTION
Fixed the broken headings in Getting Started with CLI article.

Issue reference: https://github.com/saleor/saleor.io-learn/issues/70#issue-1293300647