### PR TITLE
Update gql naming

### DIFF
--- a/product/basic-filtering.md
+++ b/product/basic-filtering.md
@@ -14,8 +14,8 @@ When fetching products using the `products` query, we can also filter them using
 The most basic form of filtering can be done using the `search` field. It takes a string value as input that is matched against the product title and description. In the following example, we want to find all the t-shirts available in our store.
 
 ```graphql
-# graphql/queries/TShirtProducts.graphql
-query TShirtProducts {
+# graphql/queries/ProductSearchTShirt.graphql
+query ProductSearchTShirt {
   products(
     first: 12
     channel: "default-channel"
@@ -37,7 +37,7 @@ query TShirtProducts {
 }
 ```
 
-Let's put this query as `TShirtProducts.graphql` in the `graphql/queries` directory.
+Let's put this query as `ProductSearchTShirt.graphql` in the `graphql/queries` directory.
 
 If the code generation is running in the watch mode, the corresponding React.js hook will be created automatically. Otherwise, run the `generate` script:
 
@@ -51,13 +51,13 @@ or
 pnpm generate
 ```
 
-In `components/ProductCollection.tsx`, we can replace the `useFetchTwelveProductsQuery` with the newly generated `useTShirtProductsQuery` as the shape of the elements in the product collection doesn't change.
+In `components/ProductCollection.tsx`, we can replace the `useProductGetTwelveElementsQuery` with the newly generated `useProductSearchTShirtQuery` as the shape of the elements in the product collection doesn't change.
 
 ```tsx{4,12}
 // components/ProductCollection.tsx
 import React from 'react';
 
-import { Product, useTShirtProductsQuery } from '@/saleor/api';
+import { Product, useProductSearchTShirtQuery } from '@/saleor/api';
 import { ProductElement } from '@/components';
 
 const styles = {
@@ -65,7 +65,7 @@ const styles = {
 }
 
 export const ProductCollection = () => {
-  const { loading, error, data } = useTShirtProductsQuery();
+  const { loading, error, data } = useProductSearchTShirtQuery();
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error</p>;

--- a/product/fetching-products.md
+++ b/product/fetching-products.md
@@ -22,8 +22,8 @@ The first operation also enables you to filter and sort a collection of products
 Let's start with a simple collection of 12 elements that returns a product `id` and `name`. Put the following GraphQL query inside the GraphQL Playground of your Saleor endpoint and execute it using the play button in the middle.
 
 ```graphql
-# graphql/queries/FetchTwelveProducts.graphql
-query FetchTwelveProducts {
+# graphql/queries/ProductGetTwelveElements.graphql
+query ProductGetTwelveElements {
   products(first: 12, channel: "default-channel") {
     edges {
       node {
@@ -71,7 +71,7 @@ Another way of controlling the number of elements to fetch is through pagination
 
 ## Autogenerate a React Hook for Products
 
-1. Put the abovementioned query in your storefront under the `graphql/queries` directory as `FetchTwelveProducts.graphql`.
+1. Put the abovementioned query in your storefront under the `graphql/queries` directory as `ProductGetTwelveElements.graphql`.
 
 2. In the Terminal, run the `generate` script to generate the corresponding React.js hooks:
 
@@ -99,7 +99,7 @@ Let's create our first React component for displaying available products as a gr
 ```tsx{3,15}
 // components/ProductCollection.tsx
 import React from 'react';
-import { useFetchTwelveProductsQuery } from '@/saleor/api';
+import { useProductGetTwelveElementsQuery } from '@/saleor/api';
 
 const styles = {
   grid: 'grid gap-4 grid-cols-4',
@@ -111,7 +111,7 @@ const styles = {
 }
 
 export const ProductCollection = () => {
-  const { loading, error, data } = useFetchTwelveProductsQuery();
+  const { loading, error, data } = useProductGetTwelveElementsQuery();
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error</p>;
@@ -142,7 +142,7 @@ export const ProductCollection = () => {
 
 ```
 
-The GraphQL Code Generator alongside the Apollo React plugin automatically generates the `useFetchTwelveProductsQuery` React hook.
+The GraphQL Code Generator alongside the Apollo React plugin automatically generates the `useProductGetTwelveElementsQuery` React hook.
 
 Once the data is available, we display the product names as a list. It's worth noticing that the product collection exists as a GraphQL edge as it stores information that goes beyond what's in each object, e.g., the count. Each collection element is a node.
 
@@ -248,8 +248,8 @@ We need to slightly modify our GraphQL query to also include the product thumbna
 Here's the modified query:
 
 ```graphql{8-13}
-# graphql/queries/FetchTwelveProducts.graphql
-query FetchTwelveProducts {
+# graphql/queries/ProductGetTwelveElements.graphql
+query ProductGetTwelveElements {
   products(first: 12, channel: "default-channel") {
     edges {
       node {
@@ -269,14 +269,14 @@ query FetchTwelveProducts {
 
 Let's use this query to replace the previous one:
 
-1. Paste the abovementioned query into the `FetchTwelveProducts.graphql` that is located in `graphql/`.
+1. Paste the abovementioned query into the `ProductGetTwelveElements.graphql` that is located in `graphql/`.
 2. If you have enabled the `watch` mode in your `generate` script, the Code Generator will now regenerate the types and update hooks for the new query. If you haven't, run `npm generate` or `pnpm generate` in your Terminal to trigger the regeneration.
 3. Head over to the `components` folder and modify the `ProductCollection.tsx` component to display the product thumbnails along with their categories:
 
 ```tsx
 // components/ProductCollection.tsx
 import React from "react";
-import { useFetchTwelveProductsQuery } from "@/saleor/api";
+import { useProductGetTwelveElementsQuery } from "@/saleor/api";
 
 const styles = {
   grid: "grid gap-4 grid-cols-4",
@@ -293,7 +293,7 @@ const styles = {
 };
 
 export const ProductCollection = () => {
-  const { loading, error, data } = useFetchTwelveProductsQuery();
+  const { loading, error, data } = useProductGetTwelveElementsQuery();
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error</p>;
@@ -389,7 +389,7 @@ export { ProductElement } from './ProductElement';
 // components/ProductCollection.tsx
 import React from "react";
 
-import { Product, useFetchTwelveProductsQuery } from "@/saleor/api";
+import { Product, useProductGetTwelveElementsQuery } from "@/saleor/api";
 import { ProductElement } from "@/components";
 
 const styles = {
@@ -397,7 +397,7 @@ const styles = {
 };
 
 export const ProductCollection = () => {
-  const { loading, error, data } = useFetchTwelveProductsQuery();
+  const { loading, error, data } = useProductGetTwelveElementsQuery();
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error</p>;

--- a/product/filtering-with-variables.md
+++ b/product/filtering-with-variables.md
@@ -11,11 +11,11 @@ next:
 
 Often the filtering criteria come from the users. We cannot put these criteria as-is into the GraphQL query. We must dynamically set them using the query variables.
 
-1. Go to the `graphql/queries` folder and create a `FilterProducts.graphql` file. Copy/paste the query below:
+1. Go to the `graphql/queries` folder and create a `ProductFilterByName.graphql` file. Copy/paste the query below:
 
 ```graphql{1,2}
-# graphql/queries/FilterProducts.graphql
-query FilterProducts($filter: ProductFilterInput!) {
+# graphql/queries/ProductFilterByName.graphql
+query ProductFilterByName($filter: ProductFilterInput!) {
   products(first: 12, channel: "default-channel", filter: $filter) {
     edges {
       node {
@@ -47,17 +47,17 @@ or
 pnpm run generate
 ```
 
-It will generate the `useFilterProductsQuery` React Hook.
+It will generate the `useProductFilterByNameQuery` React Hook.
 
 Such defined GraphQL query accepts its input via the `variables` field. This transformation is done automatically by the Apollo library along with the code generation and is available as input in its React Hook.
 
-3. In `components/ProductCollection.tsx`, replace the `useFetchTwelveProductsQuery` with the newly generated `useFilterProductsQuery` as the shape of the elements in the product collection doesn't change.
+3. In `components/ProductCollection.tsx`, replace the `useProductFetchTwelveElementsQuery` with the newly generated `useProductFilterByNameQuery` as the shape of the elements in the product collection doesn't change.
 
 ```tsx{4,12-16}
 // components/ProductCollection.tsx
 import React from 'react';
 
-import { Product, useFilterProductsQuery } from '@/saleor/api';
+import { Product, useProductFilterByNameQuery } from '@/saleor/api';
 import { ProductElement } from '@/components';
 
 const styles = {
@@ -65,7 +65,7 @@ const styles = {
 }
 
 export const ProductCollection = () => {
-  const { loading, error, data } = useFilterProductsQuery({
+  const { loading, error, data } = useProductFilterByNameQuery({
     variables: {
       filter: { search: 'juice' }
     }

--- a/product/pagination.md
+++ b/product/pagination.md
@@ -15,11 +15,11 @@ It's not a good idea to keep this information within the entity itself as it's u
 
 Let us now go through the process of adding pagination to our storefront.
 
-1. Adapt the query for fetching products so that it can be paginated. Open the `graphql/queries/FilterProducts.graphql` file and update its contents with the changes below:
+1. Adapt the query for fetching products so that it can be paginated. Open the `graphql/queries/ProductFilterByName.graphql` file and update its contents with the changes below:
 
 ```graphql{5,12,26-32}
-# graphql/queries/FilterProducts.graphql
-query FilterProducts(
+# graphql/queries/ProductFilterByName.graphql
+query ProductFilterByName(
   $filter: ProductFilterInput!
   $sortBy: ProductOrder
   $after: String
@@ -66,7 +66,7 @@ Additionally, the `products` query has the `after` argument that takes the value
 // components/ProductCollection.tsx
 import React from "react";
 
-import { Product, useFilterProductsQuery } from "@/saleor/api";
+import { Product, useProductFilterByNameQuery } from "@/saleor/api";
 import { Pagination, ProductElement } from "@/components";
 
 const styles = {
@@ -74,7 +74,7 @@ const styles = {
 };
 
 export const ProductCollection = () => {
-  const { loading, error, data, fetchMore } = useFilterProductsQuery({
+  const { loading, error, data, fetchMore } = useProductFilterByNameQuery({
     variables: {
       filter: {},
     },

--- a/product/single-product.md
+++ b/product/single-product.md
@@ -31,10 +31,10 @@ query ProductByID($id: ID!) {
 }
 ```
 
-The `product` query requires a value for the `id` argument, which is the product we want to fetch. After you run the `generate` script, you can use the `useProductByIdQuery` hook in React components with the product `id` specified via the `variables`, like so:
+The `product` query requires a value for the `id` argument, which is the product we want to fetch. After you run the `generate` script, you can use the `useProductByIDQuery` hook in React components with the product `id` specified via the `variables`, like so:
 
 ```js
-const { loading, error, data } = useProductByIdQuery({
+const { loading, error, data } = useProductByIDQuery({
   variables: {
     id: "UHJvZHVjdDoxMTE=",
   },
@@ -51,7 +51,7 @@ Let's focus on the React component first. Let's name it `ProductPage`. In the `p
 
 ```tsx
 // pages/product/[id].tsx
-import { useProductByIdQuery } from "@/saleor/api";
+import { useProductByIDQuery } from "@/saleor/api";
 import { Layout } from "@/components";
 
 const styles = {
@@ -72,7 +72,7 @@ interface Props {
 }
 
 const ProductPage = ({ id }: Props) => {
-  const { loading, error, data } = useProductByIdQuery({ variables: { id } });
+  const { loading, error, data } = useProductByIDQuery({ variables: { id } });
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error</p>;
@@ -113,7 +113,7 @@ const ProductPage = ({ id }: Props) => {
 export default ProductPage;
 ```
 
-`ProductPage` has the product identifier passed in, and then it uses that to fetch details for a particular product using the auto-generated `useProductByIdQuery`. Then, we display the product data we received. The flow is similar to the page that displays the collection of products, except that here we need an `id` of a product to display as input for this React component.
+`ProductPage` has the product identifier passed in, and then it uses that to fetch details for a particular product using the auto-generated `useProductByIDQuery`. Then, we display the product data we received. The flow is similar to the page that displays the collection of products, except that here we need an `id` of a product to display as input for this React component.
 
 Next.js provides two special functions for React components that are used as pages (i.e., the ones located in `pages/` directory) with dynamic routes: `getStaticPaths` and `getStaticProps`.
 
@@ -122,9 +122,9 @@ Next.js provides two special functions for React components that are used as pag
 ```tsx{2,3,20-35}
 // pages/product/[id].tsx
 import {
-  useProductByIdQuery,
-  FilterProductsDocument,
-  FilterProductsQuery
+  useProductByIDQuery,
+  ProductFilterByNameDocument,
+  ProductFilterByNameQuery
 } from "@/saleor/api";
 import { apolloClient } from "@/lib";
 import {
@@ -146,8 +146,8 @@ const ProductPage = ({ id }: Props) => {
 export default ProductPage;
 
 export async function getStaticPaths() {
-  const { data } = await apolloClient.query<FilterProductsQuery>({
-    query: FilterProductsDocument,
+  const { data } = await apolloClient.query<ProductFilterByNameQuery>({
+    query: ProductFilterByNameDocument,
     variables: {
       filter: {}
     }
@@ -163,7 +163,7 @@ export async function getStaticPaths() {
 }
 ```
 
-First, we are executing a GraphQL query to fetch a collection of products. We are re-using the same query we defined in the section about fetching products. Both `FilterProductsDocument` and `FilterProductsQuery` are auto-generated from the query name (`FilterProducts`). The first is the actual query, while the second is the type describing the shape of the data returned in response to that query.
+First, we are executing a GraphQL query to fetch a collection of products. We are re-using the same query we defined in the section about fetching products. Both `ProductFilterByNameDocument` and `ProductFilterByNameQuery` are auto-generated from the query name (`ProductFilterByName`). The first is the actual query, while the second is the type describing the shape of the data returned in response to that query.
 
 The response data is a collection of products. We extract just the identifier of each product using the built-in `map` function and return the result as a collection of paths.
 
@@ -202,9 +202,9 @@ The second function provided by Next.js for pages is `getStaticProps` - it retur
 import { GetStaticProps } from "next";
 
 import {
-  useProductByIdQuery,
-  FilterProductsDocument,
-  FilterProductsQuery
+  useProductByIDQuery,
+  ProductFilterByNameDocument,
+  ProductFilterByNameQuery
 } from "@/saleor/api";
 import { apolloClient } from "@/lib";
 import {
@@ -449,9 +449,9 @@ Now, we are ready to significantly reduce the size of `ProductPage`. Head over t
 import { GetStaticProps, InferGetStaticPropsType } from "next";
 
 import {
-  useProductByIdQuery,
-  FilterProductsDocument,
-  FilterProductsQuery,
+  useProductByIDQuery,
+  ProductFilterByNameDocument,
+  ProductFilterByNameQuery,
   Product
 } from "@/saleor/api";
 import { apolloClient } from "@/lib";
@@ -461,7 +461,7 @@ import {
 } from '@/components';
 
 const ProductPage = ({ id }: InferGetStaticPropsType<typeof getStaticProps>) => {
-  const { loading, error, data } = useProductByIdQuery({ variables: { id } });
+  const { loading, error, data } = useProductByIDQuery({ variables: { id } });
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error</p>;
@@ -482,8 +482,8 @@ const ProductPage = ({ id }: InferGetStaticPropsType<typeof getStaticProps>) => 
 export default ProductPage;
 
 export async function getStaticPaths() {
-  const { data } = await apolloClient.query<FilterProductsQuery>({
-    query: FilterProductsDocument,
+  const { data } = await apolloClient.query<ProductFilterByNameQuery>({
+    query: ProductFilterByNameDocument,
     variables: {
       filter: {}
     }

--- a/product/sorting.md
+++ b/product/sorting.md
@@ -13,11 +13,11 @@ The `products` query also enables us to change the order of the returned product
 
 Let's rework our previous query so that it also specifies the sorting:
 
-1. Navigate to `graphql/queries/FilterProducts.graphql` file and update the query:
+1. Navigate to `graphql/queries/ProductFilterByName.graphql` file and update the query:
 
 ```graphql{2-7}
-# graphql/queries/FilterProducts.graphql
-query FilterProducts($filter: ProductFilterInput!, $sortBy: ProductOrder) {
+# graphql/queries/ProductFilterByName.graphql
+query ProductFilterByName($filter: ProductFilterInput!, $sortBy: ProductOrder) {
   products(
     first: 12
     channel: "default-channel"
@@ -41,7 +41,7 @@ query FilterProducts($filter: ProductFilterInput!, $sortBy: ProductOrder) {
 
 ```
 
-As with filtering, we use the `$sortBy` variable on our `FilterProducts` query so that the sorting can be specified dynamically in a React component as input to its React hook.
+As with filtering, we use the `$sortBy` variable on our `ProductFilterByName` query so that the sorting can be specified dynamically in a React component as input to its React hook.
 
 2. Run the `generate` script in your Terminal or have it run in the `watch` mode, as described in the previous sections.
 3. Update the `ProductCollection.tsx` component with the changes below:
@@ -51,12 +51,12 @@ As with filtering, we use the `$sortBy` variable on our `FilterProducts` query s
 ...
 import {
   Product,
-  useFilterProductsQuery,
+  useProductFilterByNameQuery,
   OrderDirection,
   ProductOrderField
 } from '@/saleor/api';
 ...
-  const { loading, error, data } = useFilterProductsQuery({
+  const { loading, error, data } = useProductFilterByNameQuery({
     variables: {
       filter: { search: 'juice' },
       sortBy: {

--- a/setup/graphql-code-generator.md
+++ b/setup/graphql-code-generator.md
@@ -143,10 +143,10 @@ We will be putting all GraphQL statements (queries, mutations, and fragments) in
 
 2. Inside the `graphql` folder create another one called `queries`.
 
-3. Inside `queries` create a file called `ThreeProducts.graphql` and paste the following query:
+3. Inside `queries` create a file called `ProductGetThreeElements.graphql` and paste the following query:
 
 ```graphql
-query ThreeProducts {
+query ProductGetThreeElements {
   products(first: 3, channel: "default-channel") {
     edges {
       node {


### PR DESCRIPTION
Changed the naming of GQL queries to follow the `[Entity][Specifier]` convention. 