### PR TITLE
Update graphql playground link

### DIFF
--- a/setup/graphql-code-generator.md
+++ b/setup/graphql-code-generator.md
@@ -99,7 +99,7 @@ Finally, we need to configure the generator. To do that, we'll use another great
 2. Create a `.graphqlrc.yaml` file in the root of our project:
 
 ```yaml
-schema: https://tutorial.saleor.cloud/graphql/
+schema: https://vercel.saleor.cloud/graphql/
 documents: graphql/**/*.graphql
 extensions:
   codegen:


### PR DESCRIPTION
Updated the link to graphql playground in the setup section to `https://vercel.saleor.cloud/graphql/` to stay consistent with the rest of the tutorial.